### PR TITLE
Added overleaf links to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Data-Science-Toolkits-and-Architectures-group-1-
 This is our group repository for the subject Data Science Toolkits and Architectures at the University of Lucerne, where we share the results of our latest milestone.
+
+The reports of the milestone can be read on the following Overleaf pages.
+
+| Milestone | Description                          | Overleaf Link                                              |
+|-----------|--------------------------------------|------------------------------------------------------------|
+| Milestone 1 | MINIST Digit Classification with Convolutional Neural Nets  | [Overleaf Milestone 1](https://de.overleaf.com/read/kpntpycfsgcs#cab592)      |
+| Milestone 2 |      |     |
+| Milestone 3 |        |   |
+| Milestone 4 |          |   |
+
+
+


### PR DESCRIPTION
The Overleaf links provide access to the milestone documentation. 
These documents are stored in a shared Overleaf project.